### PR TITLE
[crm-2420] add new import status

### DIFF
--- a/api/external/members.html
+++ b/api/external/members.html
@@ -1112,7 +1112,7 @@ true
   "num_errors": 0,
   "groups_updated": [],
   "fields_updated": [],
-  "status": "o", # for okay (or "e" for error, "q" for queued),
+  "status": "o", # for okay (or "e" for error, "q" for queued, "p" for in progress),
   "error_message": null,
   "style": null,
   "automated_field_changes": null


### PR DESCRIPTION
Just adding a status on the import for "in progress". We currently deduce this in emma, but other apps get the import and it would be easy to just look at a persisted status.

This change updates the documentation where we show the possible status values. 