### PR TITLE
[CAMP-3664] Adding line about automate_contact_imports to API documentation

### DIFF
--- a/api/external/members.html
+++ b/api/external/members.html
@@ -427,6 +427,8 @@ The only required field is &#8220;email&#8221;. All other fields are treated as 
 <li><strong>automate_field_changes</strong> (<em>boolean</em>) &#8211; Accepts True or False. Optional. When set to True, updates made by this call will trigger
 field change workflows when appropriate. For more information on field change automation, visit our
 <a href="http://support.e2ma.net/Resource_Center/Guide_to_Automation/Trigger_events%3A_field_change">Resource Center.</a></li>
+<li><strong>automate_contact_imports</strong> (<em>boolean</em>) &#8211; Accepts True or False. Optional. When set to True, updates made by this call will
+trigger contact import workflows when appropriate.</li>
 <li><strong>source_filename</strong> (<em>string</em>) &#8211; An arbitrary string to associate with this import. This should generally be set to the filename
 that the user uploaded.</li>
 <li><strong>add_only</strong> (<em>boolean</em>) &#8211; Optional. Only add new members, ignore existing members.</li>


### PR DESCRIPTION
Adds documentation about automate_contact_imports boolean for bulk member adds.

## Related ticket
[CAMP-3664](https://myemma.atlassian.net/browse/CAMP-3664)