### PR TITLE
Update member delete verbiage in API docs

### DIFF
--- a/api/external/members.html
+++ b/api/external/members.html
@@ -595,8 +595,8 @@ be reported as &#8216;a&#8217; (active), &#8216;e&#8217; (error), or &#8216;o&#8
 <dl class="put">
 <dt id="put--#account_id-members-delete">
 <tt class="descname">PUT </tt><tt class="descname">/#account_id/members/delete</tt><a class="headerlink" href="#put--#account_id-members-delete" title="Permalink to this definition">¶</a></dt>
-<dd><p>Delete an array of members.</p>
-<p>The members will be marked as deleted and cannot be retrieved.</p>
+<dd><p>Archive an array of members.</p>
+<p>The members will be archived and will be appear in the account's Archived Items section.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -724,9 +724,8 @@ true
 <dl class="delete">
 <dt id="delete--#account_id-members-#member_id">
 <tt class="descname">DELETE </tt><tt class="descname">/#account_id/members/#member_id</tt><a class="headerlink" href="#delete--#account_id-members-#member_id" title="Permalink to this definition">¶</a></dt>
-<dd><p>Delete the specified member.</p>
-<p>The member, along with any associated response and history
-information, will be completely removed from the database.</p>
+<dd><p>Archive the specified member.</p>
+<p>The member will be archived and will appear in the account's Archived Items section.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />

--- a/api/external/members.html
+++ b/api/external/members.html
@@ -898,7 +898,7 @@ true
 <dl class="delete">
 <dt id="delete--#account_id-members">
 <tt class="descname">DELETE </tt><tt class="descname">/#account_id/members</tt><a class="headerlink" href="#delete--#account_id-members" title="Permalink to this definition">¶</a></dt>
-<dd><p>Delete all members.</p>
+<dd><p>Archive all members.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -1259,7 +1259,7 @@ true
           <dt id="put--#account_id-members-purgeall">
               <tt class="descname">PUT </tt><tt class="descname">/#account_id/members/purgeall</tt><a class="headerlink" href="#put--#account_id-members-purgeall" title="Permalink to this definition">¶</a></dt>
           <dd><dl class="docutils">
-              <dt><p>Purge all deleted members</p></dt>
+              <dt><p>Purge all archived members</p></dt>
               <dt><p>This will provide compliance with GDPR right to erasure ('right to be forgotten').</p></dt>
           </dl>
               <table class="docutils field-list" frame="void" rules="none">


### PR DESCRIPTION
This PR updates the language used to document three API calls that deal with deleting/archiving members. The members aren't actually deleted—as in purged—from the system as the language previously suggested in two of the calls. Instead, they're archived and moved to the account's Archived Items section where they can be reinstated. I also updated the language in the documentation for the call that actually _does_ purge members from an account so that we're consistently using the term "archive" where appropriate. 

Related: https://myemma.atlassian.net/browse/CRM-3112