### PR TITLE
Adding tip about account ID for HQ accounts

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,9 +138,9 @@
 </dl>
 </li>
 </ul>
-
-<b>Note:</b> If you are an HQ customer, please be sure to use a subaccount's ID in the path of your API call. 
-
+<p>
+<b>Note:</b> If you are an HQ customer, please be sure to use a subaccount's ID in the path of your API call.
+</p>
 </div>
 <div class="section" id="api-wrappers">
 <h2>API wrappers<a class="headerlink" href="#api-wrappers" title="Permalink to this headline">¶</a></h2>

--- a/index.html
+++ b/index.html
@@ -138,6 +138,9 @@
 </dl>
 </li>
 </ul>
+
+<b>Note:</b> If you are an HQ customer, please be sure to use a subaccount's ID in the path of your API call. 
+
 </div>
 <div class="section" id="api-wrappers">
 <h2>API wrappers<a class="headerlink" href="#api-wrappers" title="Permalink to this headline">¶</a></h2>


### PR DESCRIPTION
Support asked that we add a note in the public API docs reminding HQ accounts that they need to use a _subaccount ID_ when making calls to our public API, since using the agency parent account ID won't return info or otherwise interact properly with the subaccount data. This PR provides that. 

![api_doc_update](https://user-images.githubusercontent.com/23041098/116149013-a56ffe80-a6af-11eb-8cc8-f05b66f404db.png)
