### PR TITLE
Add update user subaccounts endpoint, link Accounts and Users pages up to index

### DIFF
--- a/api/external/accounts.html
+++ b/api/external/accounts.html
@@ -239,7 +239,43 @@
                             </div>
                             </p>
                         </dd></dl>
-
+                    <dl class="put">
+                        <dt id="put--#account_id">
+                            <tt class="descname">PUT</tt><tt class="descname">/#parent_account_id/enterprise/#user_id/subaccounts</tt><a class="headerlink" href="#put--#account_id" title="Permalink to this definition">¶</a></dt>
+                        <dd><p>Assign subaccounts to a user.</p>
+                            <p>This endpoint allows owners, and managers with the &#8216;manage_users&#8217; permission, to assign subaccounts to a specific &#8216;user_id&#8217;.
+                                The list of subaccounts provided in the call will overwrite the current list of subaccounts the user has access to, so you’ll need to ensure you’ve included every subaccount ID applicable to the user you are editing.
+                            </p>
+                            <table class="docutils field-list" frame="void" rules="none">
+                                <col class="field-name" />
+                                <col class="field-body" />
+                                <tbody valign="top">
+                                <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+                                    <li><strong>accounts</strong> (<em>list of integers</em>) &#8211; Required. The list of subaccounts to assign to the user.</li>
+                                </ul>
+                                </td>
+                                </tr>
+                                <tr class="field-even field"><th class="field-name">Raises :</th><td class="field-body"><tt class="docutils literal"><span class="pre">Http400</span></tt> if a non parent account is used in the route.</td>
+                                </tr>
+                                <tr class="field-even field"><th class="field-name">Raises :</th><td class="field-body"><tt class="docutils literal"><span class="pre">Http400</span></tt> if the requesting user does not have access to all accounts provided in the request body.</td>
+                                </tr>
+                                <tr class="field-even field"><th class="field-name">Raises :</th><td class="field-body"><tt class="docutils literal"><span class="pre">Http401</span></tt> if the requesting user is trying to edit a user with an equal or higher role.</td>
+                                </tr>
+                                </tbody>
+                            </table>
+                            <p>
+                            <div class="sample-response hide-response">
+                                <span style="font-weight:bold;">Sample Response</span>
+                                <a href="#" class="resp-trigger">[<span class="tshow">show</span><span class="thide">hide</span>]</a>
+                                <pre class="response">
+<b>GET /100/enterprise/name@myemma.com/subaccounts</b>
+{
+    "message": true
+}
+                                </pre>
+                            </div>
+                            </p>
+                        </dd></dl>
                 </div>
             </div>
         </div>

--- a/api/external/automation.html
+++ b/api/external/automation.html
@@ -29,7 +29,7 @@
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
     <link rel="next" title="Exports" href="exports.html" />
-    <link rel="prev" title="Emma API" href="../../index.html" />
+    <link rel="prev" title="Accounts" href="accounts.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="apple-touch-icon-precomposed" href="https://myemma.com/static/global/favicons/apple-iphone.png" />
@@ -88,7 +88,7 @@
           <a href="exports.html" title="Exports"
              accesskey="N">next</a> |</li>
         <li class="right" >
-          <a href="../../index.html" title="Emma API"
+          <a href="accounts.html" title="Accounts"
              accesskey="P">previous</a> |</li>
         <li><a href="../../index.html">audience 0.1 documentation</a> &raquo;</li>
       </ul>
@@ -247,7 +247,7 @@
         <div class="sphinxsidebarwrapper"><h3>Related Topics</h3>
 <ul>
   <li><a href="../../index.html">Documentation overview</a><ul>
-      <li>Previous: <a href="../../index.html" title="previous chapter">Emma API</a></li>
+      <li>Previous: <a href="accounts.html" title="previous chapter">Accounts</a></li>
       <li>Next: <a href="exports.html" title="next chapter">Exports</a></li>
   </ul></li>
 </ul>

--- a/api/external/subscriptions.html
+++ b/api/external/subscriptions.html
@@ -29,7 +29,7 @@
     <script type="text/javascript" src="../../_static/underscore.js"></script>
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
-    <link rel="next" title="Webhooks" href="webhooks.html" />
+    <link rel="next" title="Users" href="users.html" />
     <link rel="prev" title="Signup Forms" href="signup_forms.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
@@ -86,7 +86,7 @@
           <a href="../../http-routingtable.html" title="HTTP Routing Table"
              >routing table</a> |</li>
         <li class="right" >
-          <a href="webhooks.html" title="Webhooks"
+          <a href="users.html" title="Users"
              accesskey="N">next</a> |</li>
         <li class="right" >
           <a href="signup_forms.html" title="Signup Forms"
@@ -312,7 +312,7 @@
         "name": "Cat Fanatics",
         "description": "Cat-only newsletter subscribers"
     }
-    
+
     {
         "account_id": 100,
         "created_at": "Wed, 25 Sep 2019 21:39:34 GMT",
@@ -368,7 +368,7 @@
         {
             "import_id": 1
         }
-    
+
         true
     </pre>
     </div>
@@ -405,7 +405,7 @@
         "name": "Cat Fanatics Only",
         "description": "A newsletter for those only interested in cat products"
     }
-            
+
     {
         "account_id": 100,
         "created_at": "Wed, 25 Sep 2019 21:39:34 GMT",
@@ -443,7 +443,7 @@
 <a href="#" class="resp-trigger">[<span class="tshow">show</span><span class="thide">hide</span>]</a>
 <pre class="response">
     <b>DELETE /100/subscriptions/200</b>
-        
+
     {
         "account_id": 100,
         "created_at": "Wed, 25 Sep 2019 21:39:34 GMT",
@@ -471,7 +471,7 @@
 <ul>
   <li><a href="../../index.html">Documentation overview</a><ul>
       <li>Previous: <a href="signup_forms.html" title="previous chapter">Signup Forms</a></li>
-      <li>Next: <a href="webhooks.html" title="next chapter">Webhooks</a></li>
+      <li>Next: <a href="users.html" title="next chapter">Users</a></li>
   </ul></li>
 </ul>
 <div id="searchbox" style="display: none">

--- a/api/external/users.html
+++ b/api/external/users.html
@@ -147,7 +147,7 @@
         <div class="sphinxsidebarwrapper"><h3>Related Topics</h3>
             <ul>
                 <li><a href="../../index.html">Documentation overview</a><ul>
-                    <li>Previous: <a href="triggers.html" title="previous chapter">Triggers</a></li>
+                    <li>Previous: <a href="subscriptions.html" title="previous chapter">Subscriptions</a></li>
                     <li>Next: <a href="webhooks.html" title="next chapter">Webhooks</a></li>
                 </ul></li>
             </ul>

--- a/api/external/users.html
+++ b/api/external/users.html
@@ -139,6 +139,75 @@
                             </div>
                         </dd>
                     </dl>
+                    <dl class="get">
+                        <dt id="get--#account_id">
+                            <tt class="descname">GET</tt><tt class="descname">/#account_id/account/users</tt><a class="headerlink" href="#get--#account_id" title="Permalink to this definition">¶</a></dt>
+                        <dd><p>Lists the users of an account.</p>
+                            <p>This endpoint allows owners and managers with the &#8216;manage_users&#8217; permission to list the users for either the parent account, the parent account and all subs, or a particular subaccount.The list returned will include users that have accepted their invitation, and users that have not.</p>
+                            <p>Additionally, there are params to include subaccount users, to filter via &#8216;account_id&#8217;, and to search for a specific user. This endpoint is paginated and will need to be called with pagination params if the response includes more than 500 users.</p>
+                            <table class="docutils field-list" frame="void" rules="none">
+                                <col class="field-name" />
+                                <col class="field-body" />
+                                <tbody valign="top">
+                                <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+                                    <li><strong>include_sub_users</strong> (<em>boolean</em>) &#8211; Optional. Calling the endpoint using the &#8216;parent_account_id&#8217; and this param set to &#8216;true&#8217; will return the users associated with the parent account along with any users associated with any of the parent's subaccounts as well.<li>
+                                    <li><strong>searchterm</strong> (<em>string</em>) &#8211; Optional. Allows searching by the &#8216;user_id&#8217;, &#8216;user_name_first&#8217;, and &#8216;user_name_last&#8217; values.</li>
+                                    <li><strong>filter_accounts</strong> (<em>comma separated string</em>) &#8211; Optional. Allows filtering of the results by returning users who have access to one of the passed accounts.</li>
+                                </ul>
+                                </td>
+                                </tr>
+                                <tr class="field-odd field"><th class="field-name">Returns :</th><td class="field-body">A response with a list of users including the accounts they have access to, the permissions they have, their role, and other user related data.</td>
+                                </tr>
+                                <tr class="field-even field"><th class="field-name">Raises :</th><td class="field-body"><tt class="docutils literal"><span class="pre">Http404</span></tt> if the parent account or requesting user does not exist.</td>
+                                <tr class="field-even field"><th class="field-name">Raises :</th><td class="field-body"><tt class="docutils literal"><span class="pre">Http401</span></tt> if the requesting user does not have access to the account or the &#8216;manage_users&#8217; permission.</td>
+                                </tr>
+                                </tbody>
+                            </table>
+                            <p>
+                            <div class="sample-response hide-response">
+                                <span style="font-weight:bold;">Sample Response</span>
+                                <a href="#" class="resp-trigger">[<span class="tshow">show</span><span class="thide">hide</span>]</a>
+                                <pre class="response">
+<b>GET /100/account/users</b>
+{
+    "users": [
+        {
+            "accounts": [
+                {
+                    "account_id": 100,
+                    "account_name": "Test Parent Account"
+                }
+            ],
+            "create_ts": "Jun 21, 2012",
+            "email": "emmaHQowner@myemma.com",
+            "last_login_attempt": "Jul 22, 2021 02:47 PM",
+            "role": "Parent",
+            "user_group_list": [
+                "account_create",
+                "assets_access",
+                "billing_access",
+                "emma_account_default",
+                "emma_agency_default",
+                "emma_audience_default",
+                "emma_campaigns_default",
+                "emma_response_default",
+                "exporting_access",
+                "manage_api_key",
+                "manage_sso",
+                "manage_team",
+                "public",
+                "purging_access"
+            ],
+            "user_id": "emmaHQowner@myemma.com",
+            "user_name_first": “Test”,
+            "user_name_last": “Owner”
+        }
+    ]
+}
+                                </pre>
+                            </div>
+                            </p>
+                        </dd></dl>
                 </div>
             </div>
         </div>

--- a/api/external/webhooks.html
+++ b/api/external/webhooks.html
@@ -30,7 +30,7 @@
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
     <link rel="next" title="Pagination" href="../../pagination.html" />
-    <link rel="prev" title="Subscriptions" href="subscriptions.html" />
+    <link rel="prev" title="Users" href="users.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="apple-touch-icon-precomposed" href="https://myemma.com/static/global/favicons/apple-iphone.png" />
@@ -89,7 +89,7 @@
           <a href="pagination.html" title="Pagination"
              accesskey="N">next</a> |</li>
         <li class="right" >
-          <a href="subscriptions.html" title="Subscriptions"
+          <a href="users.html" title="Users"
              accesskey="P">previous</a> |</li>
         <li><a href="../../index.html">audience 0.1 documentation</a> &raquo;</li>
       </ul>
@@ -448,7 +448,7 @@ true
         <div class="sphinxsidebarwrapper"><h3>Related Topics</h3>
 <ul>
   <li><a href="../../index.html">Documentation overview</a><ul>
-      <li>Previous: <a href="subscriptions.html" title="previous chapter">Subscriptions</a></li>
+      <li>Previous: <a href="users.html" title="previous chapter">Users</a></li>
       <li>Next: <a href="../../pagination.html" title="next chapter">Pagination</a></li>
   </ul></li>
 </ul>

--- a/index.html
+++ b/index.html
@@ -260,6 +260,7 @@ address</em></a>.</p>
 </p>
 <div class="toctree-wrapper compound">
 <ul>
+<li class="toctree-l1"><a class="reference internal" href="api/external/accounts.html">Accounts</a></li>
 <li class="toctree-l1"><a class="reference internal" href="api/external/automation.html">Automation</a></li>
 <li class="toctree-l1"><a class="reference internal" href="api/external/exports.html">Exports</a></li>
 <li class="toctree-l1"><a class="reference internal" href="api/external/fields.html">Fields</a></li>
@@ -272,6 +273,7 @@ address</em></a>.</p>
 <li class="toctree-l1"><a class="reference internal" href="api/external/signup_forms.html">Signup Forms</a></li>
 <li class="toctree-l1"><a class="reference internal" href="api/external/subscriptions.html">Subscriptions</a></li>
 <!-- <li class="toctree-l1"><a class="reference internal" href="api/external/triggers.html">Triggers</a></li> -->
+<li class="toctree-l1"><a class="reference internal" href="api/external/users.html">Users</a></li>
 <li class="toctree-l1"><a class="reference internal" href="api/external/webhooks.html">Webhooks</a></li>
 </ul>
 </div>
@@ -370,6 +372,7 @@ minute. If you exceed the limit, you‘ll receive a response of 403 Rate Limit E
   <h3>Interested in Emma?</h3>
   <p>Emma's email marketing makes communicating simple and stylish. <a href="https://myemma.com/get-started/inquire" title="Get started today.">Get started today</a>.</p>
 </div>
+        </ul>
         </div>
       </div>
       <div class="clearer"></div>


### PR DESCRIPTION
## Summary
- Adds the update user subaccounts endpoint
- links the Accounts and Users page in the index
- changes Next/Previous links to be consistent with the new order of pages
- Closes [UMAMI-3847](https://myemma.atlassian.net/browse/UMAMI-3847) and [UMAMI-3937](https://myemma.atlassian.net/browse/UMAMI-3937)