### PR TITLE
[CRM-4264] Fixing link for download endpoint

### DIFF
--- a/api/external/response_exports.html
+++ b/api/external/response_exports.html
@@ -251,7 +251,7 @@
 
 <dl class="get">
 <dt id="get--#account_id-exports-response-#export_id-download">
-<tt class="descname">GET </tt><tt class="descname">/#account_id/exports/response/#export_id/download</tt><a class="headerlink" href="#get--#account_id-exports-response-#export_id" title="Permalink to this definition">&para;</a></dt>
+<tt class="descname">GET </tt><tt class="descname">/#account_id/exports/response/#export_id/download</tt><a class="headerlink" href="#get--#account_id-exports-response-#export_id-download" title="Permalink to this definition">&para;</a></dt>
 <dd><p>Download a file stream for the requested response export.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />


### PR DESCRIPTION
The link for the download response export endpoint was incorrect; this should fix it.