### PR TITLE
UMAMI-4694: Update list users route documentation.

### DIFF
--- a/api/external/users.html
+++ b/api/external/users.html
@@ -141,7 +141,7 @@
                     </dl>
                     <dl class="get">
                         <dt id="get--#account_id">
-                            <tt class="descname">GET</tt><tt class="descname">/#account_id/account/users</tt><a class="headerlink" href="#get--#account_id" title="Permalink to this definition">¶</a></dt>
+                            <tt class="descname">GET</tt><tt class="descname">/#account_id/accounts/users</tt><a class="headerlink" href="#get--#account_id" title="Permalink to this definition">¶</a></dt>
                         <dd><p>Lists the users of an account.</p>
                             <p>This endpoint allows owners and managers with the &#8216;manage_users&#8217; permission to list the users for either the parent account, the parent account and all subs, or a particular subaccount.The list returned will include users that have accepted their invitation, and users that have not.</p>
                             <p>Additionally, there are params to include subaccount users, to filter via &#8216;account_id&#8217;, and to search for a specific user. This endpoint is paginated and will need to be called with pagination params if the response includes more than 500 users.</p>


### PR DESCRIPTION
## Summary
- updates route for the list users endpoint to be `accounts` instead of `account`