### PR TITLE
CRM-6249: Adding params for retrieving member imports.

### DIFF
--- a/api/external/members.html
+++ b/api/external/members.html
@@ -1187,6 +1187,12 @@ true
 <col class="field-name" />
 <col class="field-body" />
 <tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+  <li><strong>named_only</strong> (<em>boolean</em>) &#8211; Accepts False or 0. Optional flag to include imports with blank source_filenames.</li>
+  <li><strong>deleted</strong> (<em>boolean</em>) &#8211; Accepts True or 1. Optional flag to include imports that have been archived.</li>
+</ul>
+</td>
+</tr>
 <tr class="field-odd field"><th class="field-name">Returns :</th><td class="field-body">An array of import details.</td>
 </tr>
 </tbody>

--- a/api/external/members.html
+++ b/api/external/members.html
@@ -1188,7 +1188,7 @@ true
 <col class="field-body" />
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-  <li><strong>named_only</strong> (<em>boolean</em>) &#8211; Accepts False or 0. Optional flag to include imports with blank source_filenames.</li>
+  <li><strong>named_only</strong> (<em>boolean</em>) &#8211; Accepts False or 0. Optional flag to include imports with blank source filenames.</li>
   <li><strong>deleted</strong> (<em>boolean</em>) &#8211; Accepts True or 1. Optional flag to include imports that have been archived.</li>
 </ul>
 </td>


### PR DESCRIPTION
## Description
Adding params for the endpoint to allow users to get deleted imports.

`GET | /<int:account_id>/members/imports`

<img width="934" alt="Screenshot 2024-10-14 at 12 05 51 PM" src="https://github.com/user-attachments/assets/189b2a65-5c8b-4e3d-906b-44ccdfbc9994">
