### PR TITLE
CRM-6389: Add Subscriptions Opt Out Event

### DIFF
--- a/api/external/webhooks.html
+++ b/api/external/webhooks.html
@@ -310,6 +310,11 @@ webhooks.</p>
     "event_name": "field_update",
     "webhook_event_id": 22,
     "description": "Fired when a field is updated."
+  },
+  {
+    "event_name": "subscriptions-member-opted-out",
+    "webhook_event_id": 23,
+    "description": "Fired when a member opts out in the subscription center."
   }
 ]
 


### PR DESCRIPTION
Adding the subscriptions opt out event to the list of webhook events.

```
{
    "description": "Fired when a member opts out in the subscription center.",
    "event_name": "subscriptions-member-opted-out",
    "webhook_event_id": 23
}
```