### PR TITLE
EE-2793: Event/event type fixes

### DIFF
--- a/api/external/events.html
+++ b/api/external/events.html
@@ -317,7 +317,7 @@
                                 <a class="headerlink" href="#delete--#account_id-member_event_type_by_id" title="Permalink to this definition">&para;</a>
                             </dt>
                             <dd>
-                                <p>Delete a specific member event type.</p>
+                                <p>Delete a specific member event type. This will also delete all events of this event type. This action is not reversable.</p>
                             </dd>
                         </dl>
                         <p>With these endpoints, you can create member events and view information about specific member's events.</p>
@@ -339,12 +339,13 @@
                                                 <li><strong>events</strong> (<em>array of JSON objects</em>) &#8211; Required. A list of member event JSON objects.
                                                     <ul class="first simple">
                                                         <li><strong>attributes</strong> (<em>JSON object</em>) &#8211; A generic JSON object that contains additional attributes about the event.</li>
-                                                        <li><strong>email</strong> (<em>string</em>) &#8211; The member email.</li>
-                                                        <li><strong>member_id</strong> (<em>string</em>) &#8211; The member ID.</li>
-                                                        <li><strong>event_type_id</strong> (<em>string</em>) &#8211; The event type ID.</li>
-                                                        <li><strong>event_type</strong> (<em>string</em>) &#8211; An existing defined event_type.</li>
+                                                        <li><strong>email</strong> (<em>string</em>) &#8211; Required if member_id is not present. The member email.</li>
+                                                        <li><strong>member_id</strong> (<em>integer</em>) &#8211; Required if email is not present. The member ID.</li>
+                                                        <li><strong>event_type_id</strong> (<em>integer</em>) &#8211; Required if event_type is not present. The event type ID.</li>
+                                                        <li><strong>event_type</strong> (<em>string</em>) &#8211; Required if event_type_id is not present. An existing defined event_type.</li>
                                                         <li><strong>event_monetary_value</strong> (<em>number</em>) &#8211; A monetary value associated with the event.</li>
-                                                        <li><strong>mailing_id</strong> (<em>string</em>) &#8211; A mailing ID to associate with the event.</li>
+                                                        <li><strong>mailing_id</strong> (<em>integer</em>) &#8211; A mailing ID to associate with the event.</li>
+                                                        <li><strong>event_timestamp</strong> (<em>datetime</em>) &#8211; Timestamp of the event.</li>
                                                     </ul>
 
                                                 </li>


### PR DESCRIPTION
# [EE-2793](https://myemma.atlassian.net/browse/EE-2793)

## Summary
- Adds warning to delete event type
- Fixes types, adds required, adds timestamp to create event

## Testing
- N/A

### Slack Post
```
Team: Enhanced Contact Data
Manager: Joe Biggert
On-Call Engineers: Manya Mutschler-Aldine
Staff Summary: event/event type api doc fixes
Affected Customers: documentation change only
```