### PR TITLE
Message click link target

### DIFF
--- a/_sources/webhooks.txt
+++ b/_sources/webhooks.txt
@@ -61,7 +61,8 @@ Message Click
 		    "mailing_id": mailing_id,
 		    "subject": mailing_subject,
 		    "timestamp": timestamp,
-		    "link_id": link_id
+		    "link_id": link_id,
+		    "link_target": "http://example.com"
 		    }
 	}
 


### PR DESCRIPTION
Update documentation for `message_click` webhook event structure so the `link_target` can be used in external systems without have to request it back from Emma using the `link_id`.

This aligns with the changes from https://github.com/emmadev/audience/pull/4475