### PR TITLE
Message Link HTML update

### DIFF
--- a/webhooks.html
+++ b/webhooks.html
@@ -152,6 +152,7 @@ that will be sent when that event occurs.</p>
         <span class="s">&quot;subject&quot;</span><span class="p">:</span> <span class="n">mailing_subject</span><span class="p">,</span>
         <span class="s">&quot;timestamp&quot;</span><span class="p">:</span> <span class="n">timestamp</span><span class="p">,</span>
         <span class="s">&quot;link_id&quot;</span><span class="p">:</span> <span class="n">link_id</span>
+        <span class="s">&quot;link_target&quot;</span><span class="p">:</span> <span class="n">http://example.com</span>
     <span class="p">}</span>
 <span class="p">}</span>
 </pre></div>

--- a/webhooks.html
+++ b/webhooks.html
@@ -152,7 +152,7 @@ that will be sent when that event occurs.</p>
         <span class="s">&quot;subject&quot;</span><span class="p">:</span> <span class="n">mailing_subject</span><span class="p">,</span>
         <span class="s">&quot;timestamp&quot;</span><span class="p">:</span> <span class="n">timestamp</span><span class="p">,</span>
         <span class="s">&quot;link_id&quot;</span><span class="p">:</span> <span class="n">link_id</span><span class="p">,</span>
-        <span class="s">&quot;link_target&quot;</span><span class="p">:</span> <span class="n">http://example.com</span>
+        <span class="s">&quot;link_target&quot;</span><span class="p">:</span> <span class="n">&quot;http://example.com&quot;</span>
     <span class="p">}</span>
 <span class="p">}</span>
 </pre></div>

--- a/webhooks.html
+++ b/webhooks.html
@@ -151,7 +151,7 @@ that will be sent when that event occurs.</p>
         <span class="s">&quot;mailing_id&quot;</span><span class="p">:</span> <span class="n">mailing_id</span><span class="p">,</span>
         <span class="s">&quot;subject&quot;</span><span class="p">:</span> <span class="n">mailing_subject</span><span class="p">,</span>
         <span class="s">&quot;timestamp&quot;</span><span class="p">:</span> <span class="n">timestamp</span><span class="p">,</span>
-        <span class="s">&quot;link_id&quot;</span><span class="p">:</span> <span class="n">link_id</span>
+        <span class="s">&quot;link_id&quot;</span><span class="p">:</span> <span class="n">link_id</span><span class="p">,</span>
         <span class="s">&quot;link_target&quot;</span><span class="p">:</span> <span class="n">http://example.com</span>
     <span class="p">}</span>
 <span class="p">}</span>


### PR DESCRIPTION
Update documentation for message_click webhook event structure so the link_target can be used in external systems without have to request it back from Emma using the link_id. We did this in a prior PR but it turns out you need to adjust the html and not just the `txt` files. 

Rendered locally:
<img width="977" height="329" alt="Screenshot 2026-03-27 at 10 18 15 AM" src="https://github.com/user-attachments/assets/e1f6a4b8-ae5b-41c1-ac46-2f0fc561e952" />



