### PR TITLE
[EE-3305] Fix broken navigation link sending users to a 404 page.

### DIFF
--- a/api/external/automation.html
+++ b/api/external/automation.html
@@ -28,7 +28,7 @@
     <script type="text/javascript" src="../../_static/underscore.js"></script>
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
-    <link rel="next" title="Touchpoints" href="touchpoints.html" />
+    <link rel="next" title="Exports" href="exports.html" />
     <link rel="prev" title="Accounts" href="accounts.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">

--- a/api/external/automation.html
+++ b/api/external/automation.html
@@ -85,7 +85,7 @@
           <a href="../../http-routingtable.html" title="HTTP Routing Table"
              >routing table</a> |</li>
         <li class="right" >
-          <a href="exports.html" title="Exports"
+          <a href="touchpoints.html" title="Touchpoints"
              accesskey="N">next</a> |</li>
         <li class="right" >
           <a href="accounts.html" title="Accounts"

--- a/api/external/automation.html
+++ b/api/external/automation.html
@@ -248,7 +248,7 @@
 <ul>
   <li><a href="../../index.html">Documentation overview</a><ul>
       <li>Previous: <a href="accounts.html" title="previous chapter">Accounts</a></li>
-      <li>Next: <a href="touchpoints.html" title="next chapter">Touchpoints</a></li>
+      <li>Next: <a href="exports.html" title="next chapter">Exports</a></li>
   </ul></li>
 </ul>
 <div id="searchbox" style="display: none">

--- a/api/external/automation.html
+++ b/api/external/automation.html
@@ -85,7 +85,7 @@
           <a href="../../http-routingtable.html" title="HTTP Routing Table"
              >routing table</a> |</li>
         <li class="right" >
-          <a href="touchpoints.html" title="Touchpoints"
+          <a href="exports.html" title="Exports"
              accesskey="N">next</a> |</li>
         <li class="right" >
           <a href="accounts.html" title="Accounts"

--- a/api/external/automation.html
+++ b/api/external/automation.html
@@ -28,7 +28,7 @@
     <script type="text/javascript" src="../../_static/underscore.js"></script>
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
-    <link rel="next" title="Events" href="events.html" />
+    <link rel="next" title="Touchpoints" href="touchpoints.html" />
     <link rel="prev" title="Accounts" href="accounts.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
@@ -248,7 +248,7 @@
 <ul>
   <li><a href="../../index.html">Documentation overview</a><ul>
       <li>Previous: <a href="accounts.html" title="previous chapter">Accounts</a></li>
-      <li>Next: <a href="events.html" title="next chapter">Events</a></li>
+      <li>Next: <a href="touchpoints.html" title="next chapter">Touchpoints</a></li>
   </ul></li>
 </ul>
 <div id="searchbox" style="display: none">

--- a/api/external/exports.html
+++ b/api/external/exports.html
@@ -30,7 +30,7 @@
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
     <link rel="next" title="Fields" href="fields.html" />
-    <link rel="prev" title="Automation" href="automation.html" />
+    <link rel="prev" title="Touchpoints" href="touchpoints.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="apple-touch-icon-precomposed" href="https://myemma.com/static/global/favicons/apple-iphone.png" />
@@ -89,7 +89,7 @@
           <a href="fields.html" title="Fields"
              accesskey="N">next</a> |</li>
         <li class="right" >
-          <a href="automation.html" title="Automation"
+          <a href="touchpoints.html" title="Touchpoints"
              accesskey="P">previous</a> |</li>
         <li><a href="../../index.html">audience 0.1 documentation</a> &raquo;</li>
       </ul>

--- a/api/external/exports.html
+++ b/api/external/exports.html
@@ -337,7 +337,7 @@ email@email.com,123456789,2022-09-19T15:04:01 UTC,f,0,active,2022-09-19T15:22:14
         <div class="sphinxsidebarwrapper"><h3>Related Topics</h3>
 <ul>
   <li><a href="../../index.html">Documentation overview</a><ul>
-      <li>Previous: <a href="events.html" title="previous chapter">Events</a></li>
+      <li>Previous: <a href="touchpoints.html" title="previous chapter">Touchpoints</a></li>
       <li>Next: <a href="fields.html" title="next chapter">Fields</a></li>
   </ul></li>
 </ul>

--- a/api/external/exports.html
+++ b/api/external/exports.html
@@ -89,7 +89,7 @@
           <a href="fields.html" title="Fields"
              accesskey="N">next</a> |</li>
         <li class="right" >
-          <a href="touchpoints.html" title="Touchpoints"
+          <a href="automation.html" title="Automation"
              accesskey="P">previous</a> |</li>
         <li><a href="../../index.html">audience 0.1 documentation</a> &raquo;</li>
       </ul>

--- a/api/external/exports.html
+++ b/api/external/exports.html
@@ -337,7 +337,7 @@ email@email.com,123456789,2022-09-19T15:04:01 UTC,f,0,active,2022-09-19T15:22:14
         <div class="sphinxsidebarwrapper"><h3>Related Topics</h3>
 <ul>
   <li><a href="../../index.html">Documentation overview</a><ul>
-      <li>Previous: <a href="touchpoints.html" title="previous chapter">Touchpoints</a></li>
+      <li>Previous: <a href="automation.html" title="previous chapter">Automation</a></li>
       <li>Next: <a href="fields.html" title="next chapter">Fields</a></li>
   </ul></li>
 </ul>

--- a/api/external/exports.html
+++ b/api/external/exports.html
@@ -30,7 +30,7 @@
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
     <link rel="next" title="Fields" href="fields.html" />
-    <link rel="prev" title="Touchpoints" href="touchpoints.html" />
+    <link rel="prev" title="Automation" href="automation.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="apple-touch-icon-precomposed" href="https://myemma.com/static/global/favicons/apple-iphone.png" />

--- a/api/external/subscriptions.html
+++ b/api/external/subscriptions.html
@@ -29,7 +29,7 @@
     <script type="text/javascript" src="../../_static/underscore.js"></script>
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
-    <link rel="next" title="Users" href="users.html" />
+    <link rel="next" title="Touchpoints" href="touchpoints.html" />
     <link rel="prev" title="SMS" href="sms.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
@@ -86,7 +86,7 @@
           <a href="../../http-routingtable.html" title="HTTP Routing Table"
              >routing table</a> |</li>
         <li class="right" >
-          <a href="users.html" title="Users"
+          <a href="touchpoints.html" title="Touchpoints"
              accesskey="N">next</a> |</li>
         <li class="right" >
           <a href="sms.html" title="SMS"
@@ -471,7 +471,7 @@
 <ul>
   <li><a href="../../index.html">Documentation overview</a><ul>
       <li>Previous: <a href="sms.html" title="previous chapter">SMS</a></li>
-      <li>Next: <a href="users.html" title="next chapter">Users</a></li>
+      <li>Next: <a href="touchpoints.html" title="next chapter">Touchpoints</a></li>
   </ul></li>
 </ul>
 <div id="searchbox" style="display: none">

--- a/api/external/touchpoints.html
+++ b/api/external/touchpoints.html
@@ -86,10 +86,10 @@
                 <a href="../../http-routingtable.html" title="HTTP Routing Table"
                 >routing table</a> |</li>
             <li class="right" >
-                <a href="fields.html" title="Fields"
+                <a href="users.html" title="Users"
                    accesskey="N">next</a> |</li>
             <li class="right" >
-                <a href="automation.html" title="Automation"
+                <a href="subscriptions.html" title="Subscriptions"
                    accesskey="P">previous</a> |</li>
             <li><a href="../../index.html">audience 0.1 documentation</a> &raquo;</li>
         </ul>
@@ -528,8 +528,8 @@
             <div class="sphinxsidebarwrapper"><h3>Related Topics</h3>
                 <ul>
                     <li><a href="../../index.html">Documentation overview</a><ul>
-                        <li>Previous: <a href="automation.html" title="previous chapter">Automation</a></li>
-                        <li>Next: <a href="exports.html" title="next chapter">Exports</a></li>
+                        <li>Previous: <a href="subscriptions.html" title="previous chapter">Subscriptions</a></li>
+                        <li>Next: <a href="users.html" title="next chapter">Users</a></li>
                     </ul></li>
                 </ul>
                 <div id="searchbox" style="display: none">

--- a/api/external/touchpoints.html
+++ b/api/external/touchpoints.html
@@ -28,7 +28,7 @@
     <script type="text/javascript" src="../../_static/underscore.js"></script>
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
-    <link rel="next" title="Fields" href="fields.html" />
+    <link rel="next" title="Exports" href="exports.html" />
     <link rel="prev" title="Automation" href="automation.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
@@ -86,7 +86,7 @@
                 <a href="../../http-routingtable.html" title="HTTP Routing Table"
                 >routing table</a> |</li>
             <li class="right" >
-                <a href="fields.html" title="Fields"
+                <a href="exports.html" title="Exports"
                    accesskey="N">next</a> |</li>
             <li class="right" >
                 <a href="automation.html" title="Automation"

--- a/api/external/touchpoints.html
+++ b/api/external/touchpoints.html
@@ -28,7 +28,7 @@
     <script type="text/javascript" src="../../_static/underscore.js"></script>
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
-    <link rel="next" title="Exports" href="exports.html" />
+    <link rel="next" title="Users" href="users.html" />
     <link rel="prev" title="Subscriptions" href="subscriptions.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">

--- a/api/external/touchpoints.html
+++ b/api/external/touchpoints.html
@@ -86,7 +86,7 @@
                 <a href="../../http-routingtable.html" title="HTTP Routing Table"
                 >routing table</a> |</li>
             <li class="right" >
-                <a href="exports.html" title="Exports"
+                <a href="fields.html" title="Fields"
                    accesskey="N">next</a> |</li>
             <li class="right" >
                 <a href="automation.html" title="Automation"

--- a/api/external/touchpoints.html
+++ b/api/external/touchpoints.html
@@ -29,7 +29,7 @@
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
     <link rel="next" title="Exports" href="exports.html" />
-    <link rel="prev" title="Automation" href="automation.html" />
+    <link rel="prev" title="Subscriptions" href="subscriptions.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="apple-touch-icon-precomposed" href="https://myemma.com/static/global/favicons/apple-iphone.png" />

--- a/api/external/users.html
+++ b/api/external/users.html
@@ -29,7 +29,7 @@
     <script type="text/javascript" src="../../_static/doctools.js"></script>
     <link rel="top" title="audience 0.1 documentation" href="../../index.html" />
     <link rel="next" title="Webhooks" href="../../webhooks.html" />
-    <link rel="prev" title="Subscriptions" href="subscriptions.html" />
+    <link rel="prev" title="Touchpoints" href="touchpoints.html" />
     <link rel="icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="shortcut icon" href="https://myemma.com/static/global/favicons/favicon.ico?v=2" type="image/x-icon">
     <link rel="apple-touch-icon-precomposed" href="https://myemma.com/static/global/favicons/apple-iphone.png" />
@@ -88,7 +88,7 @@
             <a href="webhooks.html" title="Webhooks"
                accesskey="N">next</a> |</li>
         <li class="right" >
-            <a href="subscriptions.html" title="Subscriptions"
+            <a href="touchpoints.html" title="Touchpoints"
                accesskey="P">previous</a> |</li>
         <li><a href="../../index.html">audience 0.1 documentation</a> &raquo;</li>
     </ul>
@@ -216,7 +216,7 @@
         <div class="sphinxsidebarwrapper"><h3>Related Topics</h3>
             <ul>
                 <li><a href="../../index.html">Documentation overview</a><ul>
-                    <li>Previous: <a href="subscriptions.html" title="previous chapter">Subscriptions</a></li>
+                    <li>Previous: <a href="touchpoints.html" title="previous chapter">Touchpoints</a></li>
                     <li>Next: <a href="webhooks.html" title="next chapter">Webhooks</a></li>
                 </ul></li>
             </ul>


### PR DESCRIPTION

## Specific changes made
Two HTML files had navigation links pointing to an `events.html` page, which doesn't exist anymore. This ticket updates both to point to `touchpoints.html` instead which is the updated version of the page.

## Relevant tickets
[EE-3305](https://myemma.atlassian.net/browse/EE-3305)

## Slack post
Team: Dev Support
Manager: Joe Biggert
Engineer: Bri Wyatt
Summary: Fixed a 404 on the public API docs site caused by nav links pointing to the old Events page URL
Affected: All

## Testing 
If you want to test locally, fetch this branch and then type
``` python3 -m http.server 8000```

1. Verify there is a new Link called "Touchpoints"
<img width="1679" height="876" alt="touchpoints-link-1" src="https://github.com/user-attachments/assets/6ef33562-8fc0-46e3-a531-673a60df55c5" />


2. Verify it takes you to a new page called Touchpoints


<img width="1727" height="837" alt="touchpoints-link-page" src="https://github.com/user-attachments/assets/4660946e-98e2-451e-ae9f-3030666fc11d" />


