### PR TITLE
[EE-3677] GET Mailings API Call Information Update Request

### DIFF
--- a/api/external/mailings.html
+++ b/api/external/mailings.html
@@ -286,6 +286,7 @@ when none are specified.</li>
 <dt id="get--#account_id-mailings-#mailing_id">
 <tt class="descname">GET </tt><tt class="descname">/#account_id/mailings/#mailing_id</tt><a class="headerlink" href="#get--#account_id-mailings-#mailing_id" title="Permalink to this definition">&para;</a></dt>
 <dd><p>Get detailed information for one mailing.</p>
+<p><strong>Note for automated campaigns:</strong> Automated campaigns trigger individually for each contact, so each send generates its own unique mailing ID. When using this endpoint with an automated campaign mailing ID, the response will only include information for a single mailing.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />
@@ -370,6 +371,7 @@ when none are specified.</li>
 <tt class="descname">GET </tt><tt class="descname">/#account_id/mailings/#mailing_id/members</tt><a class="headerlink" href="#get--#account_id-mailings-#mailing_id-members" title="Permalink to this definition">&para;</a></dt>
 <dd><p>Get the list of members to whom the given mailing was sent. This
 does not include groups or searches.</p>
+<p><strong>Note for automated campaigns:</strong> Automated campaigns trigger individually for each contact, so each send generates its own unique mailing ID. When using this endpoint with an automated campaign mailing ID, the response will only include one member.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />

--- a/api/external/mailings.html
+++ b/api/external/mailings.html
@@ -286,7 +286,7 @@ when none are specified.</li>
 <dt id="get--#account_id-mailings-#mailing_id">
 <tt class="descname">GET </tt><tt class="descname">/#account_id/mailings/#mailing_id</tt><a class="headerlink" href="#get--#account_id-mailings-#mailing_id" title="Permalink to this definition">&para;</a></dt>
 <dd><p>Get detailed information for one mailing.</p>
-<p><strong>Note for automated campaigns:</strong> Automated campaigns trigger individually for each contact, so each send generates its own unique mailing ID. When using this endpoint with an automated campaign mailing ID, the response will only include information for a single mailing.</p>
+<p><strong>Note for automated campaigns:</strong> Automated campaigns trigger individually for each member, so each send generates its own unique mailing ID. When using this endpoint with an automated campaign mailing ID, the response will only include information for that single mailing.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />

--- a/api/external/mailings.html
+++ b/api/external/mailings.html
@@ -371,7 +371,7 @@ when none are specified.</li>
 <tt class="descname">GET </tt><tt class="descname">/#account_id/mailings/#mailing_id/members</tt><a class="headerlink" href="#get--#account_id-mailings-#mailing_id-members" title="Permalink to this definition">&para;</a></dt>
 <dd><p>Get the list of members to whom the given mailing was sent. This
 does not include groups or searches.</p>
-<p><strong>Note for automated campaigns:</strong> Automated campaigns trigger individually for each contact, so each send generates its own unique mailing ID. When using this endpoint with an automated campaign mailing ID, the response will only include one member.</p>
+<p><strong>Note for automated campaigns:</strong> Automated campaigns trigger individually for each member, so each send generates its own unique mailing ID. When using this endpoint with an automated campaign mailing ID, the returned array will contain a single member.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name" />
 <col class="field-body" />


### PR DESCRIPTION
## What changed
Added a short note to GET /#account_id/mailings/#mailing_id and GET /#account_id/mailings/#mailing_id/members in mailings.html.

When Emma sends an automated email, it makes a brand new mailing ID for each person it sends to. One contact, one mailing. So when you pull one of those mailing IDs through these endpoints, you get back one mailing and one member. That's how it's supposed to work -- it just wasn't written down anywhere.

## Ticket
Closes [EE-3677](https://myemma.atlassian.net/browse/EE-3677)

## Slack Post
Team: Dev Support
Manager: Hunter Hamid
Engineer: Bri Wyatt
Summary: Added a doc note explaining why automation mailings only return one result per endpoint call.
Affected: All


Test plan:

Open api/external/mailings.html in a browser:

1. - Scroll to GET /#account_id/mailings/#mailing_id
Confirm the automation note is visible below the endpoint description

2. - Scroll to GET /#account_id/mailings/#mailing_id/members
Confirm a similar note is there too
