### PR TITLE
EE-3764: Update link to Doug Hurst's github

### DIFF
--- a/_sources/index.txt
+++ b/_sources/index.txt
@@ -40,7 +40,7 @@ This collection is young, but growing, and includes wrappers commissioned by Emm
     `Emma <https://github.com/markroland/emma>`_: Built by Nashville-based `Abenity, Inc <http://www.abenity.com/>`_.
 
 **Python**
-    `EmmaPython <https://github.com/myemma/EmmaPython>`_: Built by Emma's own `Doug Hurst <https://github.com/dalanhurst>`_.
+    `EmmaPython <https://github.com/myemma/EmmaPython>`_: Built by Emma's own `Doug Hurst <https://github.com/robotsnowfall>`_.
 
 **Ruby**
     `EmmaRuby <https://github.com/myemma/EmmaRuby>`_: Commissioned by Emma and built by Nashville developer `Dennis Monsewicz <https://github.com/dennismonsewicz>`_.

--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@
 <p class="last"><a class="reference external" href="https://github.com/markroland/emma">Emma</a>: Built by Nashville-based <a class="reference external" href="http://www.abenity.com/">Abenity, Inc</a>.</p>
 </dd>
 <dt><strong>Python</strong></dt>
-<dd><a class="reference external" href="https://github.com/myemma/EmmaPython">EmmaPython</a>: Built by Emma&#8217;s own <a class="reference external" href="https://github.com/dalanhurst">Doug Hurst</a>.</dd>
+<dd><a class="reference external" href="https://github.com/myemma/EmmaPython">EmmaPython</a>: Built by Emma&#8217;s own <a class="reference external" href="https://github.com/robotsnowfall">Doug Hurst</a>.</dd>
 <dt><strong>Ruby</strong></dt>
 <dd><a class="reference external" href="https://github.com/myemma/EmmaRuby">EmmaRuby</a>: Commissioned by Emma and built by Nashville developer <a class="reference external" href="https://github.com/dennismonsewicz">Dennis Monsewicz</a>.</dd>
 <dt><strong>Objective-C</strong></dt>


### PR DESCRIPTION
## Summary
Updates the link to Doug Hurst's current github page.